### PR TITLE
feat(Lexicon): handle sentinels from executing try catch finally

### DIFF
--- a/storyruntime/processing/Lexicon.py
+++ b/storyruntime/processing/Lexicon.py
@@ -347,11 +347,12 @@ class Lexicon:
         the catch block or finally block.
         """
         next_line = story.next_block(line)
+        result_sentinel = None
 
         if next_line is None:
             return None
 
-        async def next_block_or_finally():
+        async def next_block_or_finally(result_sentinel):
             """
             This will execute if the next block is a finally block.
             It happens because the lexicon should always execute
@@ -366,30 +367,43 @@ class Lexicon:
 
             if last_block is not None and \
                     last_block['method'] == 'finally':
-                await Lexicon.execute_block(logger, story,
-                                            last_block)
+                exec_res = await Lexicon.execute_block(logger, story,
+                                                       last_block)
+                if LineSentinels.is_sentinel(exec_res):
+                    # Sentinels are banned inside finally block for now.
+                    # This is to avoid conflicts with sentinels being
+                    # returned from executing the try or the catch block.
+                    # To be reconsidered when a strong use case arises.
+                    raise InvalidKeywordUsage(story, line, exec_res.keyword)
                 last_block = story.next_block(last_block)
 
+            if result_sentinel is not None:
+                return result_sentinel
             return Lexicon.line_number_or_none(last_block)
 
         try:
-            await Lexicon.execute_block(logger, story, line)
+            exec_res = await Lexicon.execute_block(logger, story, line)
+            if LineSentinels.is_sentinel(exec_res):
+                result_sentinel = exec_res
         except StoryscriptError as e:
             if next_line['method'] == 'finally':
                 # skip right to the finally block
-                return await next_block_or_finally()
+                return await next_block_or_finally(result_sentinel)
 
             try:
-                await Lexicon.execute_block(logger, story, next_line)
+                exec_res = await Lexicon.execute_block(
+                    logger, story, next_line)
+                if LineSentinels.is_sentinel(exec_res):
+                    result_sentinel = exec_res
             except StoryscriptError as re:
                 # if the catch block contains a StoryscriptError,
                 # we must catch it, and run the finally
                 # block anyway, followed up by raising the
                 # exception
-                await next_block_or_finally()
+                await next_block_or_finally(result_sentinel)
                 raise re
 
-        return await next_block_or_finally()
+        return await next_block_or_finally(result_sentinel)
 
     @staticmethod
     def throw(logger, story, line):

--- a/tests/integration/processing/Lexicon.py
+++ b/tests/integration/processing/Lexicon.py
@@ -2004,31 +2004,30 @@ async def test_float_mutations(suite: Suite, logger):
 
 
 @mark.parametrize('suite', [
-    TestSuite(
-        preparation_lines='function test a: int b: int returns string\n'
-                          '    try\n'
-                          '        if a % 2 == 0\n'
-                          '            return "even"\n'
-                          '        a = a / b\n'
-                          '    catch\n'
-                          '        return "error"\n'
-                          '    finally\n'
-                          '        if a % 2 == 0 and b == 0\n'
-                          '            return "evenoverride"\n'
-                          '    return "odd"\n',
+    Suite(preparation_lines='function test a: int b: int returns string\n'
+                            '    try\n'
+                            '        if a % 2 == 0\n'
+                            '            return "even"\n'
+                            '        a = a / b\n'
+                            '    catch\n'
+                            '        return "error"\n'
+                            '    finally\n'
+                            '        if a % 2 == 0 and b == 0\n'
+                            '            return "evenoverride"\n'
+                            '    return "odd"\n',
         cases=[
-            TestCase(append='a = test(a: 10 b: 1)',
-                     assertion=ContextAssertion(key='a', expected='even')),
-            TestCase(append='a = test(a: 10 b: 0)',
-                     assertion=RuntimeExceptionAssertion(
-                         exception_type=StoryscriptError,
-                         message='Invalid usage of keyword "return".'
-                     )),
-            TestCase(append='a = test(a: 11 b: 0)',
-                     assertion=ContextAssertion(key='a', expected='error'))
+            Case(append='a = test(a: 10 b: 1)',
+                 assertion=ContextAssertion(key='a', expected='even')),
+            Case(append='a = test(a: 10 b: 0)',
+                 assertion=RuntimeExceptionAssertion(
+                     exception_type=StoryscriptError,
+                     message='Invalid usage of keyword "return".'
+                 )),
+            Case(append='a = test(a: 11 b: 0)',
+                 assertion=ContextAssertion(key='a', expected='error'))
         ]
     )
 ])
 @mark.asyncio
-async def test_try_catch(suite: TestSuite, logger):
+async def test_try_catch(suite: Suite, logger):
     await run_suite(suite, logger)

--- a/tests/integration/processing/Lexicon.py
+++ b/tests/integration/processing/Lexicon.py
@@ -2001,3 +2001,34 @@ async def test_range_mutations(suite: TestSuite, logger):
 @mark.asyncio
 async def test_float_mutations(suite: TestSuite, logger):
     await run_suite(suite, logger)
+
+
+@mark.parametrize('suite', [
+    TestSuite(
+        preparation_lines='function test a: int b: int returns string\n'
+                          '    try\n'
+                          '        if a % 2 == 0\n'
+                          '            return "even"\n'
+                          '        a = a / b\n'
+                          '    catch\n'
+                          '        return "error"\n'
+                          '    finally\n'
+                          '        if a % 2 == 0 and b == 0\n'
+                          '            return "evenoverride"\n'
+                          '    return "odd"\n',
+        cases=[
+            TestCase(append='a = test(a: 10 b: 1)',
+                     assertion=ContextAssertion(key='a', expected='even')),
+            TestCase(append='a = test(a: 10 b: 0)',
+                     assertion=RuntimeExceptionAssertion(
+                         exception_type=StoryscriptError,
+                         message='Invalid usage of keyword "return".'
+                     )),
+            TestCase(append='a = test(a: 11 b: 0)',
+                     assertion=ContextAssertion(key='a', expected='error'))
+        ]
+    )
+])
+@mark.asyncio
+async def test_try_catch(suite: TestSuite, logger):
+    await run_suite(suite, logger)

--- a/tests/integration/processing/Lexicon.py
+++ b/tests/integration/processing/Lexicon.py
@@ -2026,7 +2026,7 @@ async def test_float_mutations(suite: Suite, logger):
               Case(append='a = test(a: 11 b: 0)',
                    assertion=ContextAssertion(key='a', expected='error'))
           ]
-    )
+          )
 ])
 @mark.asyncio
 async def test_try_catch(suite: Suite, logger):

--- a/tests/integration/processing/Lexicon.py
+++ b/tests/integration/processing/Lexicon.py
@@ -2015,17 +2015,17 @@ async def test_float_mutations(suite: Suite, logger):
                             '        if a % 2 == 0 and b == 0\n'
                             '            return "evenoverride"\n'
                             '    return "odd"\n',
-        cases=[
-            Case(append='a = test(a: 10 b: 1)',
-                 assertion=ContextAssertion(key='a', expected='even')),
-            Case(append='a = test(a: 10 b: 0)',
-                 assertion=RuntimeExceptionAssertion(
-                     exception_type=StoryscriptError,
-                     message='Invalid usage of keyword "return".'
-                 )),
-            Case(append='a = test(a: 11 b: 0)',
-                 assertion=ContextAssertion(key='a', expected='error'))
-        ]
+          cases=[
+              Case(append='a = test(a: 10 b: 1)',
+                   assertion=ContextAssertion(key='a', expected='even')),
+              Case(append='a = test(a: 10 b: 0)',
+                   assertion=RuntimeExceptionAssertion(
+                       exception_type=StoryscriptError,
+                       message='Invalid usage of keyword "return".'
+                   )),
+              Case(append='a = test(a: 11 b: 0)',
+                   assertion=ContextAssertion(key='a', expected='error'))
+          ]
     )
 ])
 @mark.asyncio


### PR DESCRIPTION
This will make sure cases like the following work fine:
```
a = ["foo", "bar"]
foreach a as s
    try
        if s == "bar"
            continue
        when twitter stream tweet track: s as result
            log info msg: result['text']
    finally
        log info msg: "wow"
```

Right now sentinels from within try catch aren't bubbled up.
We should be doing that.

Fixes: #511 