### PR TITLE
Pin versions of the test deps to that mentioned in the tox.ini.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,10 @@ setup(
     version='0.2.0',
     packages=find_packages(),
     tests_require=[
-        'pytest==4.2.0',
-        'pytest-cov==2.6.1',
-        'pytest-mock==1.10.1',
-        'pytest-asyncio==0.10.0'
+        'pytest==3.6.3',
+        'pytest-cov==2.5.1',
+        'pytest-mock==1.10.0',
+        'pytest-asyncio==0.8.0'
     ],
     setup_requires=['pytest-runner'],
     python_requires='>=3.7',


### PR DESCRIPTION
The motivation for this is to enable users to simply clone the project, and then be able to run python setup.py test. Will and I explored another option of forcing users to run tox instead of the setuptools test, but were unable to successfully override the test command and print a decent message. Hence, for now, we'll just pin the same versions (since they rarely change anyway).