### PR TITLE
chore(test): Sync setup.py and tox test depends

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,12 +21,14 @@ setup(
     author='Storyscript',
     author_email='noreply@storyscript.io',
     version='0.2.0',
-    packages=find_packages(),
+    packages=find_packages(
+        exclude=('build.*', 'bench', 'bench.*', 'tests', 'tests.*'),
+    ),
     tests_require=[
-        'pytest==4.2.0',
-        'pytest-cov==2.6.1',
-        'pytest-mock==1.10.1',
-        'pytest-asyncio==0.10.0'
+        'pytest',
+        'pytest-cov',
+        'pytest-mock',
+        'pytest-asyncio',
     ],
     setup_requires=['pytest-runner'],
     python_requires='>=3.7',

--- a/tox.ini
+++ b/tox.ini
@@ -1,21 +1,26 @@
 [tox]
+minversion = 1.6
 envlist = py37,pep8
+skip_missing_interpreters = true
 
-
-[testenv:py37]
+[testenv]
 passenv = DOCKER_HOST DOCKER_MACHINE_NAME DOCKER_TLS_VERIFY DOCKER_CERT_PATH
+# These deps are optional here, as `setup.py pytest` will install them anyway
+# if omitted, however tox does it more neatly, and developers may want to try
+# various pins here, and setup.py will not overrule them.
 deps =
-    pytest==3.6.3
-    pytest-cov==2.5.1
-    pytest-mock==1.10.0
-    pytest-asyncio==0.8.0
+    pytest
+    pytest-cov
+    pytest-mock
+    pytest-asyncio
 
 commands =
-    pytest --cov=. --cov-config=.coveragerc --cov-report=term-missing {posargs}
+    python setup.py pytest --addopts="--cov=storyruntime --cov-config=.coveragerc --cov-report=term-missing {posargs}"
     coverage xml
 
-
 [testenv:pep8]
+usedevelop = true
+skip_install = true
 deps =
     flake8==3.5.0
     flake8-quotes==1.0.0


### PR DESCRIPTION
Also prevent installation of `bench` and tests`, and
focus the coverage on the relevant package only.