### PR TITLE
Allow list + list

### DIFF
--- a/storyruntime/utils/Resolver.py
+++ b/storyruntime/utils/Resolver.py
@@ -186,14 +186,15 @@ class Resolver:
         elif a == 'sum':
             result = left
 
-            assert type(left) in (int, float, str)
+            assert type(left) in (int, float, str, list)
             # Sum supports flattened values since this only occurs when
             # a string like "{a} {b} {c}" is compiled. Everything else,
             # including arithmetic is compiled as a nested expression.
             for i in range(1, len(values)):
                 r = cls.resolve(values[i], data)
 
-                if type(r) in (int, float) and type(result) in (int, float):
+                if type(r) in (int, float, list) and \
+                        type(result) in (int, float, list):
                     result += r
                 else:
                     result = f'{str(result)}{str(r)}'

--- a/tests/integration/processing/Lexicon.py
+++ b/tests/integration/processing/Lexicon.py
@@ -1339,6 +1339,17 @@ async def test_arrays(suite, logger, run_suite):
         ]
     ),
     Suite(
+        preparation_lines='a = [1, 2, 3]\n'
+                          'b = [3, 4, 5]\n'
+                          'c = a + b',
+        cases=[
+            Case(
+                assertion=ContextAssertion(key='c',
+                                           expected=[1, 2, 3, 3, 4, 5])
+            )
+        ]
+    ),
+    Suite(
         preparation_lines='foo = 2\n'
                           'zero = 0\n'
                           'a = 2 * 4 / (4 * foo) + 1 * 20 + zero',


### PR DESCRIPTION
Closes #270

Docs list the following types, of which the ones highlighted in bold can be added at the moment:

- comments
- boolean
- **numbers (int, float)**
- **strings**
- **lists**
- maps
- **time**
- regex