### PR TITLE
Storyscript 0.25

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'click==7.0',
         'frustum==0.0.6',
         'sentry-sdk==0.10.2',
-        'storyscript==0.24.2',
+        'storyscript==0.25.0',
         'ujson==1.35',
         'certifi>=2018.8.24',
         'asyncpg==0.18.3',

--- a/tests/integration/processing/Lexicon.py
+++ b/tests/integration/processing/Lexicon.py
@@ -310,7 +310,7 @@ from .Assertions import ContextAssertion, IsANumberAssertion, \
     Suite(
         preparation_lines='a = 1283',
         cases=[
-            Case(append='b = a + ""',
+            Case(append='b = "{a}"',
                  assertion=ContextAssertion(key='b', expected='1283'))
         ]
     ),
@@ -507,8 +507,8 @@ from .Assertions import ContextAssertion, IsANumberAssertion, \
     ),
     Suite(
         preparation_lines='a = [1, 2, 3, 4, 5]\n'
-                          'b = [] as List[int]\n'
-                          'c = [] as List[int]\n',
+                          'b = [] to List[int]\n'
+                          'c = [] to List[int]\n',
         cases=[
             Case(append='foreach a as elem\n'
                         '   b = b.append(item: elem)\n'
@@ -1174,7 +1174,7 @@ from .Assertions import ContextAssertion, IsANumberAssertion, \
                           'b = 10s',
         cases=[
             Case(
-                append='aString = a as string',
+                append='aString = a to string',
                 assertion=ContextAssertion(
                     key='aString',
                     expected='1000'
@@ -1182,7 +1182,7 @@ from .Assertions import ContextAssertion, IsANumberAssertion, \
             ),
             Case(
                 append='sum = a + b\n'
-                       'sumString = sum as string',
+                       'sumString = sum to string',
                 assertion=ContextAssertion(
                     key='sumString',
                     expected='11000'
@@ -1377,7 +1377,7 @@ async def test_arrays(suite, logger, run_suite):
         ]
     ),
     Suite(
-        preparation_lines='a = {} as Map[any,int]\n',
+        preparation_lines='a = {} to Map[any,int]\n',
         cases=[
             Case(append='a["b"] = 1',
                  assertion=MapValueAssertion(key='a',
@@ -1410,17 +1410,54 @@ async def test_arrays(suite, logger, run_suite):
         ]
     ),
     Suite(
-        preparation_lines='a = {"a": 1, "b": {} as Map[string,string],'
+        preparation_lines='a = {"a": 1, "b": {} to Map[string,string],'
                           ' "c": 3}\n'
                           'b = ["a", "b", "c"]\n'
-                          'c = 1',
+                          'c = 1\n',
         cases=[
             Case(
-                append='a[b[c]][c] = -1',
+                append='m = a[b[c]] to Map[int,int]\n'
+                       'm[1] = -1\n',
+                assertion=ContextAssertion(key='a',
+                                           expected={
+                                               'a': 1, 'b': {}, 'c': 3
+                                           })
+            ),
+            Case(
+                append='m = a[b[c]] to Map[int,int]\n'
+                       'm[1] = -1\n'
+                       'a[b[c]] = m',
                 assertion=ContextAssertion(key='a',
                                            expected={
                                                'a': 1, 'b': {1: -1}, 'c': 3
                                            })
+            ),
+        ]
+    ),
+    Suite(
+        preparation_lines='a = ["1", 2]\n',
+        cases=[
+            Case(
+                append='m = a to List[int]\n'
+                       'm[1] = -1',
+                assertion=[ContextAssertion(key='a',
+                                            expected=['1', 2]),
+                           ContextAssertion(key='m',
+                                            expected=[1, -1])]
+            ),
+            Case(
+                append='m = a to List[int]\n'
+                       'm[1] = -1\n'
+                       'a = m',
+                assertion=ContextAssertion(key='a',
+                                           expected=[1, -1])
+            ),
+            Case(
+                append='m = a to List[int]\n'
+                       'm[0] = 0\n'
+                       'a = m',
+                assertion=ContextAssertion(key='a',
+                                           expected=[0, 2])
             )
         ]
     )
@@ -1674,56 +1711,56 @@ async def test_resolve_all_objects(suite: Suite, logger, run_suite):
 @mark.parametrize('suite', [
     Suite(
         cases=[
-            Case(append='a = [0] as List[int]',
+            Case(append='a = [0] to List[int]',
                  assertion=ContextAssertion(key='a', expected=[0])),
-            Case(append='a = [] as List[int]',
+            Case(append='a = [] to List[int]',
                  assertion=ContextAssertion(key='a', expected=[])),
-            Case(append='a = ["3", "2"] as List[int]',
+            Case(append='a = ["3", "2"] to List[int]',
                  assertion=ContextAssertion(key='a', expected=[3, 2])),
-            Case(append='a = 2 as float',
+            Case(append='a = 2 to float',
                  assertion=ContextAssertion(key='a', expected=2.)),
-            Case(append='a = 2.5 as int',
+            Case(append='a = 2.5 to int',
                  assertion=ContextAssertion(key='a', expected=2)),
-            Case(append='a = 2 as string',
+            Case(append='a = 2 to string',
                  assertion=ContextAssertion(key='a', expected='2')),
-            Case(append='a = {2: "42"} as Map[float,float]',
+            Case(append='a = {2: "42"} to Map[float,float]',
                  assertion=ContextAssertion(key='a', expected={2.: 42.})),
-            Case(append='a = "foo" as regex',
+            Case(append='a = "foo" to regex',
                  assertion=ContextAssertion(key='a',
                                             expected=re.compile('foo'))),
-            Case(append='a = /foo/ as regex',
+            Case(append='a = /foo/ to regex',
                  assertion=ContextAssertion(key='a',
                                             expected=re.compile('foo'))),
-            Case(append='a = 2 as any',
+            Case(append='a = 2 to any',
                  assertion=ContextAssertion(key='a', expected=2)),
-            Case(append='a = true as int',
+            Case(append='a = true to int',
                  assertion=ContextAssertion(key='a', expected=1)),
-            Case(append='a = false as int',
+            Case(append='a = false to int',
                  assertion=ContextAssertion(key='a', expected=0)),
-            Case(append='a = {"foo": 42} as Map[string,int]',
+            Case(append='a = {"foo": 42} to Map[string,int]',
                  assertion=ContextAssertion(key='a',
                                             expected={'foo': 42})),
-            Case(append='a = {} as Map[int,boolean]',
+            Case(append='a = {} to Map[int,boolean]',
                  assertion=ContextAssertion(key='a',
                                             expected={}))
         ]
     ),
     Suite(
-        preparation_lines='arr = [] as List[any]\n'
+        preparation_lines='arr = [] to List[any]\n'
                           'arr = arr.append(item: 42)\n'
                           'b = arr[0]',
         cases=[
-            Case(append='c = b as List[int]',
+            Case(append='c = b to List[int]',
                  assertion=RuntimeExceptionAssertion(
                      TypeAssertionRuntimeError,
                      message='Incompatible type assertion: Received 42 '
                              '(int), but expected List[int]')),
-            Case(append='c = b as Map[int,string]',
+            Case(append='c = b to Map[int,string]',
                  assertion=RuntimeExceptionAssertion(
                      TypeAssertionRuntimeError,
                      message='Incompatible type assertion: Received 42 '
                              '(int), but expected Map[int,string]')),
-            Case(append='b=/foo/\nc = b as List[int]',
+            Case(append='b=/foo/\nc = b to List[int]',
                  assertion=RuntimeExceptionAssertion(
                      TypeAssertionRuntimeError,
                      message='Incompatible type assertion: Received /foo/ '
@@ -1732,28 +1769,28 @@ async def test_resolve_all_objects(suite: Suite, logger, run_suite):
     ),
     Suite(
         cases=[
-            Case(append='c = "foo" as float',
+            Case(append='c = "foo" to float',
                  assertion=RuntimeExceptionAssertion(
                      TypeValueRuntimeError,
                      message='Type conversion failed from str to float '
                              'with `foo`')),
-            Case(append='c = "foo" as int',
+            Case(append='c = "foo" to int',
                  assertion=RuntimeExceptionAssertion(
                      TypeValueRuntimeError,
                      message='Type conversion failed from str to int '
                              'with `foo`')),
-            Case(append='c = "foo" as string',
+            Case(append='c = "foo" to string',
                  assertion=ContextAssertion(key='c', expected='foo')),
-            Case(append='c = "10" as int',
+            Case(append='c = "10" to int',
                  assertion=ContextAssertion(key='c', expected=10)),
-            Case(append='c = "10.1" as float',
+            Case(append='c = "10.1" to float',
                  assertion=ContextAssertion(key='c', expected=10.1)),
-            Case(append='c = [0, 1, 2] as string',
+            Case(append='c = [0, 1, 2] to string',
                  assertion=ContextAssertion(key='c', expected='[0, 1, 2]')),
-            Case(append='c = {"a": "b", "c": 10} as string',
+            Case(append='c = {"a": "b", "c": 10} to string',
                  assertion=ContextAssertion(
                      key='c', expected='{"a": "b", "c": 10}')),
-            Case(append='c = [{"a":"b"}, {}, {"c": 10}] as string',
+            Case(append='c = [{"a":"b"}, {}, {"c": 10}] to string',
                  assertion=ContextAssertion(
                      key='c', expected='[{"a": "b"}, {}, {"c": 10}]')),
         ]
@@ -1881,11 +1918,11 @@ async def test_range_mutations(suite: Suite, logger, run_suite):
                 assertion=ContextAssertion(key='b', expected=1)
             ),
             Case(
-                append='a = "nan" as float\nb = a.isNaN()',
+                append='a = "nan" to float\nb = a.isNaN()',
                 assertion=ContextAssertion(key='b', expected=True)
             ),
             Case(
-                append='a = "inf" as float\nb = a.isInfinity()',
+                append='a = "inf" to float\nb = a.isInfinity()',
                 assertion=ContextAssertion(key='b', expected=True)
             ),
             Case(

--- a/tests/unit/processing/Lexicon.py
+++ b/tests/unit/processing/Lexicon.py
@@ -179,8 +179,7 @@ async def test_if_condition_1(patch, logger, magic):
             'ln': '1',
             'method': 'if',
             'parent': None,
-            'enter': '2',
-            'next': '2'
+            'enter': '2'
         },
         '2': {
             'ln': '2',
@@ -205,12 +204,11 @@ async def test_if_condition_2(patch, logger, magic):
             'ln': '1',
             'method': 'if',
             'enter': '2',
-            'next': '2'
+            'next': '3'
         },
         '2': {
             'ln': '2',
             'parent': '1',
-            'next': '3'
         },
         '3': {
             'ln': '3',
@@ -247,69 +245,66 @@ def test__is_if_condition_true_complex(patch, story):
 @mark.parametrize('case', [
     # case[0] - side_effect for Lexicon._is_if_condition_true
     # case[1] - expected line number to be returned
-    [[True, False, False], '2'],
-    [[False, True, False], '4'],
-    [[False, False, True], '6'],
-    [[False, False, False], '8'],
+    [[True, False, False], '3'],
+    [[False, True, False], '5'],
+    [[False, False, True], '7'],
+    [[False, False, False], None],
 ])
 @mark.asyncio
-async def test_if_condition(patch, logger, magic, case):
+async def test_if_condition(patch, logger, magic, case, async_mock):
     tree = {
         '1': {
             'ln': '1',
             'method': 'if',
             'parent': None,
             'enter': '2',
-            'next': '2'
+            'next': '3'
         },
         '2': {
             'ln': '2',
             'parent': '1',
-            'next': '3'
         },
         '3': {
             'ln': '3',
             'method': 'elif',
             'parent': None,
             'enter': '4',
-            'next': '4'
+            'next': '5'
         },
         '4': {
             'ln': '4',
             'parent': '3',
-            'next': '5'
         },
         '5': {
             'ln': '5',
             'method': 'elif',
             'parent': None,
             'enter': '6',
-            'next': '6'
+            'next': '7'
         },
         '6': {
             'ln': '6',
             'parent': '5',
-            'next': '7'
         },
         '7': {
             'ln': '7',
             'method': 'else',
             'parent': None,
-            'next': '8',
             'enter': '8'
         },
         '8': {
             'ln': '8',
-            'parent': '7',
-            'next': None
+            'parent': '7'
         }
     }
 
     patch.object(Lexicon, '_is_if_condition_true', side_effect=case[0])
+    patch.object(Lexicon, 'execute_block', new=async_mock())
     story = Story(magic(), 'foo', logger)
 
     story.tree = tree
     ret = await Lexicon.if_condition(logger, story, tree['1'])
+    Lexicon.execute_block.mock.assert_called()
     assert ret == case[1]
 
 
@@ -679,22 +674,22 @@ async def test_lexicon_execute_block(patch, logger, story,
 @mark.parametrize('tree', [
     {
         '1': {
-            'method': 'try', 'ln': '1', 'enter': '2', 'exit': '3', 'next': '2'
+            'method': 'try', 'ln': '1', 'enter': '2', 'exit': '3', 'next': '3'
         },
         '2': {
             'method': 'execute', 'ln': '2', 'output': [], 'service': 'log',
-            'command': 'info', 'parent': '1', 'next': '3'
+            'command': 'info', 'parent': '1'
         },
         '3': {
             'method': 'catch', 'ln': '3', 'output': [],
-            'enter': '4', 'exit': '5', 'next': '4'
+            'enter': '4', 'exit': '5', 'next': '5'
         },
         '4': {
             'method': 'execute', 'ln': '4', 'output': [], 'service': 'log',
-            'command': 'info', 'parent': '3', 'next': '5'
+            'command': 'info', 'parent': '3'
         },
         '5': {
-            'method': 'finally', 'ln': '5', 'enter': '6', 'next': '6'
+            'method': 'finally', 'ln': '5', 'enter': '6'
         },
         '6': {
             'method': 'execute', 'ln': '6', 'output': [], 'service': 'log',
@@ -703,14 +698,14 @@ async def test_lexicon_execute_block(patch, logger, story,
     },
     {
         '1': {
-            'method': 'try', 'ln': '1', 'enter': '2', 'exit': '3', 'next': '2'
+            'method': 'try', 'ln': '1', 'enter': '2', 'exit': '3', 'next': '3'
         },
         '2': {
             'method': 'execute', 'ln': '2', 'output': [], 'service': 'log',
-            'command': 'info', 'parent': '1', 'next': '3'
+            'command': 'info', 'parent': '1'
         },
         '3': {
-            'method': 'finally', 'ln': '3', 'enter': '4', 'next': '4'
+            'method': 'finally', 'ln': '3', 'enter': '4'
         },
         '4': {
             'method': 'execute', 'ln': '4', 'output': [],
@@ -719,22 +714,22 @@ async def test_lexicon_execute_block(patch, logger, story,
     },
     {
         '1': {
-            'method': 'try', 'ln': '1', 'enter': '2', 'exit': '3', 'next': '2'
+            'method': 'try', 'ln': '1', 'enter': '2', 'exit': '3', 'next': '3'
         },
         '2': {
             'method': 'execute', 'ln': '2', 'output': [], 'service': 'log',
-            'command': 'info', 'parent': '1', 'next': '3'
+            'command': 'info', 'parent': '1'
         },
         '3': {
             'method': 'catch', 'ln': '3', 'output': [],
-            'enter': '4', 'exit': '5', 'next': '4'
+            'enter': '4', 'exit': '5', 'next': '5'
         },
         '4': {
             'method': 'execute', 'ln': '4', 'output': [], 'service': 'log',
-            'command': 'fail', 'parent': '3', 'next': '5'
+            'command': 'fail', 'parent': '3'
         },
         '5': {
-            'method': 'finally', 'ln': '5', 'enter': '6', 'next': '6'
+            'method': 'finally', 'ln': '5', 'enter': '6'
         },
         '6': {
             'method': 'execute', 'ln': '6', 'output': [], 'service': 'log',
@@ -743,26 +738,26 @@ async def test_lexicon_execute_block(patch, logger, story,
     },
     {
         '1': {
-            'method': 'try', 'ln': '1', 'enter': '2', 'exit': '3', 'next': '2'
+            'method': 'try', 'ln': '1', 'enter': '2', 'exit': '3', 'next': '3'
         },
         '2': {
             'method': 'execute', 'ln': '2', 'output': [], 'service': 'log',
-            'command': 'info', 'parent': '1', 'next': '3'
+            'command': 'info', 'parent': '1'
         },
         '3': {
             'method': 'catch', 'ln': '3', 'output': [],
-            'enter': '4', 'exit': '5', 'next': '4'
+            'enter': '4', 'exit': '5', 'next': '5'
         },
         '4': {
             'method': 'execute', 'ln': '4', 'output': [], 'service': 'log',
-            'command': 'info', 'parent': '3', 'next': '5'
+            'command': 'info', 'parent': '3'
         },
         '5': {
             'method': 'execute', 'ln': '5', 'output': [], 'service': 'log',
             'command': 'info'
         }
     }])
-async def test_lexicon_try_catch(patch, magic, logger, tree):
+async def test_lexicon_try_catch(patch, magic, logger, tree, async_mock):
     story = Story(magic(), 'foo', logger)
 
     story.tree = tree
@@ -783,6 +778,8 @@ async def test_lexicon_try_catch(patch, magic, logger, tree):
             return await execute_block(*args)
 
     patch.object(Lexicon, 'execute_block', side_effect=execute_block_proxy)
+    output = MagicMock()
+    patch.object(Services, 'execute', new=async_mock(return_value=output))
 
     if should_throw_exc:
         with pytest.raises(StoryscriptError):
@@ -809,6 +806,7 @@ async def test_lexicon_try_catch(patch, magic, logger, tree):
     }],
     []
 ])
+@mark.asyncio
 async def test_lexicon_throw(logger, story, args):
     story.tree = {
         '1': {


### PR DESCRIPTION
TODO:
- [x] fix null (allow comparison + set of `null`) -> https://github.com/storyscript/storyscript/pull/1233
- [x] look at `as` behavior (currently `as` expects to result in a copy. This is enforced by the compiler as it's currently the only way to create a copy and also has a few tests here):

```
            Case(append='a = {2: "42"} as Map[float,float]',
                 assertion=ContextAssertion(key='a', expected={2.: 42.})),
```