### PR TITLE
Lexicon#execute should look at "enter", and not "next".

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ prometheus-client==0.2.0
 requests==2.22.0
 sentry-sdk==0.10.2
 story-hub==0.1.10         # via storyscript
-storyscript==0.25.4
+storyscript==0.25.6
 tornado==5.0.2
 ujson==1.35
 urllib3==1.25.6           # via requests, sentry-sdk

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         "click==7.0",
         "frustum==0.0.6",
         "sentry-sdk==0.10.2",
-        "storyscript==0.25.4",
+        "storyscript==0.25.6",
         "ujson==1.35",
         "certifi>=2018.8.24",
         "asyncpg==0.18.3",

--- a/storyruntime/processing/Lexicon.py
+++ b/storyruntime/processing/Lexicon.py
@@ -54,7 +54,7 @@ class Lexicon:
                 assign={"paths": line.get("output")},
             )
 
-            return Lexicon.line_number_or_none(story.line(line.get("next")))
+            return Lexicon.line_number_or_none(story.line(line.get("enter")))
         else:
             output = await Services.execute(story, line)
             Metrics.container_exec_seconds_total.labels(

--- a/tests/unit/processing/Lexicon.py
+++ b/tests/unit/processing/Lexicon.py
@@ -449,7 +449,7 @@ async def test_lexicon_execute_streaming_container(patch, story, async_mock):
         assign={"paths": line.get("output")},
     )
     Metrics.container_start_seconds_total.labels().observe.assert_called_once()
-    story.line.assert_called_with(line["next"])
+    story.line.assert_called_with(line["enter"])
     Lexicon.line_number_or_none.assert_called_with(story.line())
     assert ret == Lexicon.line_number_or_none()
 


### PR DESCRIPTION
This is a change with the compiler, starting from 0.25.0.

Closes #646