### PR TITLE
Raise exception for service metrics error

### DIFF
--- a/storyruntime/ServiceUsage.py
+++ b/storyruntime/ServiceUsage.py
@@ -81,7 +81,7 @@ class ServiceUsage:
             return None
         for pod in body["items"]:
             # Assert 1:1 container to pod mapping
-            if len(pod["containers"]) > 1:
+            if len(pod["containers"]) != 1:
                 raise K8sError(
                     message=f'Found {len(pod["containers"])} containers '
                     f'in pod {pod["metadata"]["name"]}, expected 1'


### PR DESCRIPTION
Related to https://github.com/storyscript/runtime/issues/573

I can't seem to figure out why any pod would have no containers, so this will help us see that pod's name when such a situation occurs