### PR TITLE
Don't attempt to scrape metrics for crashed containers

### DIFF
--- a/storyruntime/ServiceUsage.py
+++ b/storyruntime/ServiceUsage.py
@@ -80,8 +80,11 @@ class ServiceUsage:
             # Metrics not available yet
             return None
         for pod in body["items"]:
+            if len(pod["containers"]) == 0:
+                # Crashed container
+                continue
             # Assert 1:1 container to pod mapping
-            if len(pod["containers"]) != 1:
+            if len(pod["containers"]) > 1:
                 raise K8sError(
                     message=f'Found {len(pod["containers"])} containers '
                     f'in pod {pod["metadata"]["name"]}, expected 1'
@@ -93,6 +96,10 @@ class ServiceUsage:
             memory_bytes.append(
                 cls.memory_bytes(pod["containers"][0]["usage"]["memory"])
             )
+
+        if len(cpu_units) == 0:
+            # All containers for this service are in a crashed state
+            return None
 
         return {
             "service_tag_uuid": service_tag_uuid,

--- a/tests/unit/ServiceUsage.py
+++ b/tests/unit/ServiceUsage.py
@@ -116,6 +116,11 @@ async def test_start_metrics_recorder(patch, async_mock, app, metrics):
         },
         {
             "service_tag_uuid": "08605d2c-9305-474a-949b-d57a6f01c62c",
+            "k8s_response": {"items": [{"containers": []}]},
+            "metrics": None,
+        },
+        {
+            "service_tag_uuid": "08605d2c-9305-474a-949b-d57a6f01c62c",
             "k8s_response": {
                 "items": [
                     {


### PR DESCRIPTION
Closes #573

For containers that have not started yet, k8s reports no metrics for their pods - and this check is accounted for already..

but it looks like if a container crashes, the API still returns metrics for it, except they're just empty