### PR TITLE
Update pytest-cov config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ deps =
 extras = pytest
 passenv = DOCKER_HOST DOCKER_MACHINE_NAME DOCKER_TLS_VERIFY DOCKER_CERT_PATH
 commands =
-  pytest --cov=storyruntime --cov-config=setup.cfg --cov-report=term-missing --cov-report=xml {posargs}
+  pytest --cov=. --cov-config=setup.cfg --cov-report=term-missing --cov-report=xml {posargs}
 
 [testenv:stylecheck]
 extras = stylecheck


### PR DESCRIPTION
Fixes #687 

> For Codecov to operate properly, all files in the coverage report must match the git/hg file structure.