### PR TITLE
[0.26] Allow iteration on strings

### DIFF
--- a/storyruntime/processing/Lexicon.py
+++ b/storyruntime/processing/Lexicon.py
@@ -466,8 +466,15 @@ class Lexicon:
         Evaluates a foreach loop.
         """
         data = story.resolve(line["args"][0], encode=False)
-        assert type(data) in [list, dict], f"Cannot iterate over {type(data)}"
-        iterable = enumerate(data) if isinstance(data, list) else data.items()
+        assert type(data) in [
+            list,
+            dict,
+            str,
+        ], f"Cannot iterate over {type(data)}"
+        if isinstance(data, list) or isinstance(data, str):
+            iterable = enumerate(data)
+        else:
+            iterable = data.items()
 
         output = line["output"]
         assert (
@@ -476,10 +483,11 @@ class Lexicon:
 
         for a, b in iterable:
             if len(output) == 1:
-                story.set_variable(
-                    assign={"paths": output},
-                    output=b if isinstance(data, list) else a,
-                )
+                if isinstance(data, list) or isinstance(data, str):
+                    output_val = b
+                else:
+                    output_val = a
+                story.set_variable(assign={"paths": output}, output=output_val)
             else:
                 story.set_variable(assign={"paths": [output[0]]}, output=a)
                 story.set_variable(assign={"paths": [output[1]]}, output=b)

--- a/tests/integration/processing/Lexicon.py
+++ b/tests/integration/processing/Lexicon.py
@@ -1012,6 +1012,32 @@ async def test_stacked_contexts(suite: Suite, logger, run_suite):
                 )
             ],
         ),
+        Suite(
+            preparation_lines='a = "abc"\n' 'b = ""\n',
+            cases=[
+                Case(
+                    append="foreach a as elem\n"
+                    '   if elem == "a"\n'
+                    "       continue\n"
+                    "   b += elem\n",
+                    assertion=ContextAssertion(key="b", expected="bc"),
+                )
+            ],
+        ),
+        Suite(
+            preparation_lines='a = "abc"\n' 'b = ""\n' "c = 0\n",
+            cases=[
+                Case(
+                    append="foreach a as i, elem\n"
+                    "   b += elem\n"
+                    "   c += i\n",
+                    assertion=[
+                        ContextAssertion(key="b", expected="abc"),
+                        ContextAssertion(key="c", expected=3),
+                    ],
+                )
+            ],
+        ),
     ],
 )
 @mark.asyncio


### PR DESCRIPTION
Storyscript change: https://github.com/storyscript/storyscript/pull/1307 (-> PR will fail for now).

I guess `"abc".split(by: "")` could also work. OTOH string operations are fairly common. Hence, I'm not entirely sure on this one.

Your opinion is wanted.