### PR TITLE
Don't try to deploy deleted apps

### DIFF
--- a/storyruntime/Apps.py
+++ b/storyruntime/Apps.py
@@ -82,21 +82,6 @@ class Apps:
             )
             return
 
-        if release.deleted:
-            await Database.update_release_state(
-                logger, config, app_id, release.version, ReleaseState.NO_DEPLOY
-            )
-            logger.warn(
-                f"Deployment halted {app_id}@{release.version}; "
-                f"deleted={release.deleted}; "
-                f"maintenance={release.maintenance}"
-            )
-            logger.warn(
-                f"State changed to NO_DEPLOY for {app_id}@"
-                f"{release.version}"
-            )
-            return
-
         await Database.update_release_state(
             logger, config, app_id, release.version, ReleaseState.DEPLOYING
         )
@@ -334,6 +319,10 @@ class Apps:
                     f"expected {config.APP_ENVIRONMENT}, "
                     f"but got {release.app_environment})"
                 )
+                return
+
+            if release.deleted:
+                glogger.warn(f"Not deploying app {app_id} since it is deleted")
                 return
 
             if release.state == ReleaseState.FAILED.value:

--- a/storyruntime/db/Database.py
+++ b/storyruntime/db/Database.py
@@ -51,6 +51,7 @@ class Database:
             from releases
                      inner join apps on releases.app_uuid = apps.uuid
             where environment = $1
+            and not apps.deleted
             group by app_uuid;
             """
             return await con.fetch(query, config.APP_ENVIRONMENT.value)

--- a/tests/unit/db/Database.py
+++ b/tests/unit/db/Database.py
@@ -94,6 +94,7 @@ async def test_get_all_app_uuids_for_deployment(config, pool):
             from releases
                      inner join apps on releases.app_uuid = apps.uuid
             where environment = $1
+            and not apps.deleted
             group by app_uuid;
             """
     await Database.get_all_app_uuids_for_deployment(config)


### PR DESCRIPTION
Fixes #671 

Reproduced as:

- Run `story apps delete`. This sets `app.deleted = True` and sends a notification to the runtime which sets the latest release's state to `NO_DEPLOY`.
- When the runtime restarts, it still recieves the app's UUID from `Database.get_all_app_uuids_for_deployment` since that doesn't check for `app.deleted` or `NO_DEPLOY`.
- This UUID is passed on to `Database.get_release_for_deployment` which tries to find the release to deploy for the app. This function discards releases that have `state` set to `NO_DEPLOY`, so it's unable to find an appropriate release, causing the error.

The following weird behavior still remains though:

- If you delete an app that has 10 releases, the delete action will only set the latest release to `NO_DEPLOY`. The runtime will attempt to deploy each of the 9 releases every time it restarts, and set their state to `NO_DEPLOY` one at a time.

Should we make it so that the moment any one release's state is set to `NO_DEPLOY` as a result of the app being deleted, all other releases of the app are also set to `NO_DEPLOY`?